### PR TITLE
Support for @charset

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,34 @@ module.exports = function(grunt) {
         files: {
           'tmp/no_basedir_options.css': ['test/fixtures/test.css', 'test/fixtures/import.css', 'test/fixtures/component_a/css/style.css']
         }
+      },
+      single_charset: {
+        options: {
+        },
+        files: {
+          'tmp/single_charset.css': ['test/fixtures/test.css', 'test/fixtures/charset.css', 'test/fixtures/component_a/css/style.css']
+        }
+      },
+      multiple_charsets: {
+        options: {
+        },
+        files: {
+          'tmp/multiple_charsets.css': ['test/fixtures/test.css', 'test/fixtures/charset.css', 'test/fixtures/charset_latin-9.css', 'test/fixtures/component_a/css/style.css']
+        }
+      },
+      multiple_charsets_different_order: {
+        options: {
+        },
+        files: {
+          'tmp/multiple_charsets_different_order.css': ['test/fixtures/test.css', 'test/fixtures/charset_latin-9.css', 'test/fixtures/charset.css', 'test/fixtures/component_a/css/style.css']
+        }
+      },
+      multiple_charsets_single_file: {
+        options: {
+        },
+        files: {
+          'tmp/multiple_charsets_single_file.css': ['test/fixtures/charset_latin-9.css']
+        }
       }
     },
 

--- a/tasks/concat_css.js
+++ b/tasks/concat_css.js
@@ -38,6 +38,17 @@ module.exports = function(grunt) {
         }
       };
 
+      var extractCharsetStatements = function (data){
+        var rex = /@charset\s.+\;/gim;
+        var replaceRex = /[\s]*@charset\s.+\;/gim;
+        var matches = data.css.match(rex);
+        if(matches && matches.length > 0){
+          grunt.log.write("Found " + matches.join(", "));
+          data.charsets = matches;
+          data.css = data.css.replace(replaceRex, '');
+        }
+      };
+
       var rebaseUrls = function (data) {
         function dirname(csspath){
           var splits = csspath.split('/');
@@ -91,6 +102,7 @@ module.exports = function(grunt) {
       };
 
       var imports = "";
+      var charsets = [];
       var cssFragments = [];
 
       options.debugMode && console.log(f.src, f.dest);
@@ -109,12 +121,18 @@ module.exports = function(grunt) {
         if (data.imports) {
           imports += data.imports.join("\n") + "\n";
         }
+        extractCharsetStatements(data);
+        if (data.charsets) {
+          charsets = charsets.concat(data.charsets);
+        }
         cssFragments.push(data.css.replace(/(^\s+|\s+$)/g,''));
         return data;
       });
 
+      var charset = charsets[0] ? charsets[0] + '\n' : '';
+
       // Write the destination file.
-      grunt.file.write(f.dest, imports + cssFragments.join('\n') + '\n');
+      grunt.file.write(f.dest, charset + imports + cssFragments.join('\n') + '\n');
 
       // Print a success message.
       grunt.log.writeln('File "' + f.dest + '" created.');

--- a/test/concat_css_test.js
+++ b/test/concat_css_test.js
@@ -54,5 +54,33 @@ exports.concat_css = {
     var expected = grunt.file.read('test/expected/no_basedir_options.css').split('\n');
     test.deepEqual(actual, expected, 'All URLs should have been rebased');
     test.done();
+  },
+
+  single_charset: function(test) {
+    var actual = grunt.file.read('tmp/single_charset.css').split('\n');
+    var expected = grunt.file.read('test/expected/charset.css').split('\n');
+    test.deepEqual(actual, expected, 'All URLs should have been rebased');
+    test.done();
+  },
+
+  multiple_charsets: function(test) {
+    var actual = grunt.file.read('tmp/multiple_charsets.css').split('\n');
+    var expected = grunt.file.read('test/expected/multiple_charsets.css').split('\n');
+    test.deepEqual(actual, expected, 'All URLs should have been rebased');
+    test.done();
+  },
+
+  multiple_charsets_different_order: function(test) {
+    var actual = grunt.file.read('tmp/multiple_charsets_different_order.css').split('\n');
+    var expected = grunt.file.read('test/expected/multiple_charsets_different_order.css').split('\n');
+    test.deepEqual(actual, expected, 'All URLs should have been rebased');
+    test.done();
+  },
+
+  multiple_charsets_single_file: function(test) {
+    var actual = grunt.file.read('tmp/multiple_charsets_single_file.css').split('\n');
+    var expected = grunt.file.read('test/expected/multiple_charsets_single_file.css').split('\n');
+    test.deepEqual(actual, expected, 'All URLs should have been rebased');
+    test.done();
   }
 };

--- a/test/expected/charset.css
+++ b/test/expected/charset.css
@@ -1,0 +1,23 @@
+@charset "UTF-8";
+body: {
+  background-color: #EFEFEF;
+  background-image: url(http://somewebsite.com/pix.jpg);
+}
+
+.header: {
+  background-image: url(assets/images/pix.jpg);
+}
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.heart {
+  content: '♥';
+}
+
+.thunder {
+  content: '↯';
+}
+.component_a {
+  background: url('../images/nasty-texture.png');
+}

--- a/test/expected/multiple_charsets.css
+++ b/test/expected/multiple_charsets.css
@@ -1,0 +1,34 @@
+@charset "UTF-8";
+body: {
+  background-color: #EFEFEF;
+  background-image: url(http://somewebsite.com/pix.jpg);
+}
+
+.header: {
+  background-image: url(assets/images/pix.jpg);
+}
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.heart {
+  content: '♥';
+}
+
+.thunder {
+  content: '↯';
+}
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.euro {
+  content: '€'
+}
+
+.oe {
+  content: 'œ'
+}
+.component_a {
+  background: url('../images/nasty-texture.png');
+}

--- a/test/expected/multiple_charsets_different_order.css
+++ b/test/expected/multiple_charsets_different_order.css
@@ -1,0 +1,34 @@
+@charset "iso-8859-15";
+body: {
+  background-color: #EFEFEF;
+  background-image: url(http://somewebsite.com/pix.jpg);
+}
+
+.header: {
+  background-image: url(assets/images/pix.jpg);
+}
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.euro {
+  content: '€'
+}
+
+.oe {
+  content: 'œ'
+}
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.heart {
+  content: '♥';
+}
+
+.thunder {
+  content: '↯';
+}
+.component_a {
+  background: url('../images/nasty-texture.png');
+}

--- a/test/expected/multiple_charsets_single_file.css
+++ b/test/expected/multiple_charsets_single_file.css
@@ -1,0 +1,12 @@
+@charset "iso-8859-15";
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.euro {
+  content: '€'
+}
+
+.oe {
+  content: 'œ'
+}

--- a/test/fixtures/charset.css
+++ b/test/fixtures/charset.css
@@ -1,0 +1,12 @@
+@charset "UTF-8";
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.heart {
+  content: '♥';
+}
+
+.thunder {
+  content: '↯';
+}

--- a/test/fixtures/charset_latin-9.css
+++ b/test/fixtures/charset_latin-9.css
@@ -1,0 +1,13 @@
+@charset "iso-8859-15";
+@charset "windows-1252";
+/*
+ * Sample above taken from MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+ */
+
+.euro {
+  content: '€'
+}
+
+.oe {
+  content: 'œ'
+}


### PR DESCRIPTION
When concatenating several CSS files special care needs to be taken with `@charset`. It needs to be extracted and put at the top of the resulting concatenated file to generate a valid CSS file.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@charset)

> The `@charset` CSS at-rule specifies the character encoding used in the style sheet. It must be the first element in the style sheet and not be preceded by any character 
