### PR TITLE
use standard path.normalize instead of own implementation

### DIFF
--- a/tasks/concat_css.js
+++ b/tasks/concat_css.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
         function dataTransformUrlFunc(basedir) {
           var bd = basedir;
           return function(_, b) {
-            return "url('"+normalize([bd, b].join('/'))+"')";
+            return "url('"+path.normalize([bd, b].join('/'))+"')";
           };
         }
 
@@ -57,24 +57,8 @@ module.exports = function(grunt) {
         function dataTransformImportAlternateFunc(basedir) {
           var bd = basedir;
           return function(_, b) {
-            return "@import url('"+normalize([bd, b].join('/'))+"')";
+            return "@import url('"+path.normalize([bd, b].join('/'))+"')";
           };
-        }
-
-        /**
-         * remove upFolder(..) part of an URL
-         */
-        function normalize(url) {
-          var computedParts = [];
-          var parts = url.split('/');
-          for (var i in parts){
-            if (parts[i] === '..') {
-              computedParts.pop();
-            } else {
-              computedParts.push(parts[i]);
-            }
-          }
-          return computedParts.join('/');
         }
 
         function computeBaseUrl() {


### PR DESCRIPTION
current implementation do not cares about up folder string (..) if it is last in path, so 'path1/../../path2' becomes 'path2' instead of '../path2' it acctually crashes some concated files if asset is in separate folder branch.
And there is actually standard and tested implementation of normalize in standard node lib already required. 